### PR TITLE
remove slash on prefix in findAll function

### DIFF
--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -76,7 +76,7 @@ abstract class AbstractClient
         $mapping = $this->sdk->getMapping();
         $prefix = $mapping->getIdPrefix();
         $key = $mapping->getKeyFromClientName(get_called_class());
-        $data = $this->restClient->get('/' . $prefix . '/' . $key);
+        $data = $this->restClient->get($prefix . '/' . $key);
 
         if ($data && !empty($data['hydra:member'])) {
             $serializer = $this->sdk->getSerializer();


### PR DESCRIPTION
Other uses of prefix don't include the "/" before, this commit fixes the call in findAll to normalize.