### PR TITLE
Get pagination information

### DIFF
--- a/Tests/Units/Collection/HydraCollection.php
+++ b/Tests/Units/Collection/HydraCollection.php
@@ -33,7 +33,21 @@ class HydraCollection extends atoum
             ->and
             ->integer($collection->getTotalItems())->isEqualTo(6)
             ->and
-            ->array($collection->toArray())->isEqualTo($json['hydra:member']);
+            ->array($collection->toArray())->isEqualTo($json['hydra:member'])
 
+            ;
+
+    }
+
+    public function testCreateHydraCollectionWithNoData()
+    {
+        $this
+            ->given($collection = new \Mapado\RestClientSdk\Collection\HydraCollection())
+
+            ->then
+            ->object($collection)
+            ->isInstanceOf('Mapado\RestClientSdk\Collection\HydraCollection')
+            ->hasSize(0)
+        ;
     }
 }

--- a/Tests/Units/Collection/HydraCollection.php
+++ b/Tests/Units/Collection/HydraCollection.php
@@ -28,7 +28,7 @@ class HydraCollection extends atoum
             ->then
             ->object($collection)
             ->isInstanceOf('Mapado\RestClientSdk\Collection\HydraCollection')
-            ->isInstanceOf('\Iterator')
+            ->isInstanceOf('\Traversable')
             ->hasSize(6)
             ->and
             ->integer($collection->getTotalItems())->isEqualTo(6)

--- a/Tests/Units/Collection/HydraCollection.php
+++ b/Tests/Units/Collection/HydraCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mapado\RestClientSdk\Tests\Units\Collection;
+
+use atoum;
+
+/**
+ * SdkClient
+ *
+ * @uses   atoum
+ * @author Florent Clerc <florent.clerc@mapado.com>
+ */
+class HydraCollection extends atoum
+{
+    /**
+     * testCreateCollection
+     *
+     * @access public
+     * @return void
+     */
+    public function testCreateHydraCollection()
+    {
+        $json = json_decode(file_get_contents(__DIR__ . '/../../data/ticketing.list.json'), true);
+
+        $this
+            ->given($collection = new \Mapado\RestClientSdk\Collection\HydraCollection($json))
+
+            ->then
+            ->object($collection)
+            ->isInstanceOf('Mapado\RestClientSdk\Collection\HydraCollection')
+            ->isInstanceOf('\Iterator')
+            ->hasSize(6)
+            ->and
+            ->integer($collection->getTotalItems())->isEqualTo(6)
+            ->and
+            ->array($collection->toArray())->isEqualTo($json['hydra:member']);
+
+    }
+}

--- a/Tests/Units/Collection/HydraPaginatedCollection.php
+++ b/Tests/Units/Collection/HydraPaginatedCollection.php
@@ -29,7 +29,7 @@ class HydraPaginatedCollection extends atoum
             ->then
             ->object($collection)
             ->isInstanceOf('Mapado\RestClientSdk\Collection\HydraPaginatedCollection')
-            ->isInstanceOf('\Iterator')
+            ->isInstanceOf('\Traversable')
             ->hasSize(2)
             ->and
             ->integer($collection->getTotalItems())->isEqualTo(6)

--- a/Tests/Units/Collection/HydraPaginatedCollection.php
+++ b/Tests/Units/Collection/HydraPaginatedCollection.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Mapado\RestClientSdk\Tests\Units\Collection;
+
+use atoum;
+
+/**
+ * SdkClient
+ *
+ * @uses   atoum
+ * @author Florent Clerc <florent.clerc@mapado.com>
+ */
+class HydraPaginatedCollection extends atoum
+{
+
+    /**
+     * testCreateHydraPaginatedCollection
+     *
+     * @access public
+     * @return void
+     */
+    public function testCreateHydraPaginatedCollection()
+    {
+        $json = json_decode(file_get_contents(__DIR__ . '/../../data/ticketing.list.paginated.json'), true);
+
+        $this
+            ->given($collection = new \Mapado\RestClientSdk\Collection\HydraPaginatedCollection($json))
+
+            ->then
+            ->object($collection)
+            ->isInstanceOf('Mapado\RestClientSdk\Collection\HydraPaginatedCollection')
+            ->isInstanceOf('\Iterator')
+            ->hasSize(2)
+            ->and
+            ->integer($collection->getTotalItems())->isEqualTo(6)
+            ->and
+            ->array($collection->toArray())->isEqualTo($json['hydra:member'])
+            ->and
+            ->variable($collection->getFirstPage())->isEqualTo($json['hydra:firstPage'])
+            ->and
+            ->variable($collection->getLastPage())->isEqualTo($json['hydra:lastPage'])
+            ->and
+            ->variable($collection->getNextPage())->isEqualTo($json['hydra:nextPage']);
+    }
+}

--- a/Tests/data/ticketing.list.json
+++ b/Tests/data/ticketing.list.json
@@ -1,0 +1,44 @@
+{
+    "@context": "/v1/contexts/Ticketing",
+    "@id": "/v1/ticketings",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 6,
+    "hydra:member": [
+        {
+            "@id": "/v1/ticketings/1",
+            "@type": "Ticketing",
+            "activityUuid": "e41c7e98-6b10-4159-bce1-372177cf0731",
+            "eventDateList": []
+        },
+        {
+            "@id": "/v1/ticketings/2",
+            "@type": "Ticketing",
+            "activityUuid": "9c1fa0b6-815f-4860-b419-3ce93cc50d54",
+            "eventDateList": []
+        },
+        {
+            "@id": "/v1/ticketings/3",
+            "@type": "Ticketing",
+            "activityUuid": "ef43e596-7906-42ac-a5b4-01803bf25f47",
+            "eventDateList": []
+        },
+        {
+            "@id": "/v1/ticketings/4",
+            "@type": "Ticketing",
+            "activityUuid": "8cb634d5-3ddf-4a67-8d10-8078bc673346",
+            "eventDateList": []
+        },
+        {
+            "@id": "/v1/ticketings/5",
+            "@type": "Ticketing",
+            "activityUuid": "4ca1a037-a134-4c86-9dcb-5db78162faab",
+            "eventDateList": []
+        },
+        {
+            "@id": "/v1/ticketings/6",
+            "@type": "Ticketing",
+            "activityUuid": "060993ee-d70f-4ab7-8e44-8003093eba82",
+            "eventDateList": []
+        }
+    ]
+}

--- a/Tests/data/ticketing.list.paginated.json
+++ b/Tests/data/ticketing.list.paginated.json
@@ -1,0 +1,24 @@
+{
+    "@context": "/v1/contexts/Ticketing",
+    "@id": "/v1/ticketings",
+    "@type": "hydra:PaginatedCollection",
+    "hydra:nextPage": "/v1/ticketings?page=2",
+    "hydra:totalItems": 6,
+    "hydra:itemsPerPage": 2,
+    "hydra:firstPage": "/v1/ticketings",
+    "hydra:lastPage": "/v1/ticketings?page=3",
+    "hydra:member": [
+        {
+            "@id": "/v1/ticketings/1",
+            "@type": "Ticketing",
+            "activityUuid": "e41c7e98-6b10-4159-bce1-372177cf0731",
+            "eventDateList": []
+        },
+        {
+            "@id": "/v1/ticketings/2",
+            "@type": "Ticketing",
+            "activityUuid": "9c1fa0b6-815f-4860-b419-3ce93cc50d54",
+            "eventDateList": []
+        }
+    ]
+}

--- a/src/Collection/HydraCollection.php
+++ b/src/Collection/HydraCollection.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Mapado\RestClientSdk\Collection;
+
+/**
+ * Class HydraCollection
+ *
+ * @author Florent Clerc <florent.clerc@mapado.com>
+ */
+class HydraCollection implements \Iterator, \Serializable, \Countable, \ArrayAccess
+{
+    private $elements;
+    private $count = 0;
+    private $totalItems = 0;
+
+    public function __construct($response)
+    {
+        $this->elements = $response['hydra:member'];
+        $this->count = count($this->elements);
+
+        if (!empty($response['hydra:totalItems'])) {
+            $this->totalItems = $response['hydra:totalItems'];
+        }
+    }
+
+    /**
+     *  return array
+     */
+    public function toArray()
+    {
+        return $this->elements;
+    }
+
+    public function current()
+    {
+        return current($this->elements);
+    }
+
+    public function key()
+    {
+        return key($this->elements);
+    }
+
+    public function next()
+    {
+        return next($this->elements);
+    }
+
+    public function rewind()
+    {
+        reset($this->elements);
+    }
+
+    public function valid()
+    {
+        $key = key($this->elements);
+        return ($key !== null && $key !== false);
+    }
+
+    public function serialize()
+    {
+        return serialize($this->elements);
+    }
+
+    public function unserialize($values)
+    {
+        $this->elements = unserialize($values);
+    }
+
+    public function count()
+    {
+        return $this->count;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->elements[] = $value;
+        } else {
+            $this->elements[$offset] = $value;
+        }
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->elements[$offset]);
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->elements[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return isset($this->elements[$offset]) ? $this->elements[$offset] : null;
+    }
+
+    /**
+     *  return int
+     */
+    public function getTotalItems()
+    {
+        return $this->totalItems;
+    }
+}

--- a/src/Collection/HydraCollection.php
+++ b/src/Collection/HydraCollection.php
@@ -2,12 +2,14 @@
 
 namespace Mapado\RestClientSdk\Collection;
 
+use \ArrayIterator;
+
 /**
  * Class HydraCollection
  *
  * @author Florent Clerc <florent.clerc@mapado.com>
  */
-class HydraCollection implements \Iterator, \Serializable, \Countable, \ArrayAccess
+class HydraCollection implements \IteratorAggregate, \Serializable, \Countable, \ArrayAccess
 {
     private $elements;
     private $count = 0;
@@ -29,32 +31,6 @@ class HydraCollection implements \Iterator, \Serializable, \Countable, \ArrayAcc
     public function toArray()
     {
         return $this->elements;
-    }
-
-    public function current()
-    {
-        return current($this->elements);
-    }
-
-    public function key()
-    {
-        return key($this->elements);
-    }
-
-    public function next()
-    {
-        return next($this->elements);
-    }
-
-    public function rewind()
-    {
-        reset($this->elements);
-    }
-
-    public function valid()
-    {
-        $key = key($this->elements);
-        return ($key !== null && $key !== false);
     }
 
     public function serialize()
@@ -94,6 +70,11 @@ class HydraCollection implements \Iterator, \Serializable, \Countable, \ArrayAcc
     public function offsetGet($offset)
     {
         return isset($this->elements[$offset]) ? $this->elements[$offset] : null;
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->elements);
     }
 
     /**

--- a/src/Collection/HydraCollection.php
+++ b/src/Collection/HydraCollection.php
@@ -17,17 +17,11 @@ class HydraCollection implements \IteratorAggregate, \Serializable, \Countable, 
     private $elements;
 
     /**
-     * @var integer the number of elements
-     */
-    private $count = 0;
-
-    /**
      * @param array response - The Hydra data as an array
      */
     public function __construct($response)
     {
         $this->elements = $response['hydra:member'];
-        $this->count = count($this->elements);
     }
 
     /**
@@ -65,7 +59,17 @@ class HydraCollection implements \IteratorAggregate, \Serializable, \Countable, 
      */
     public function count()
     {
-        return $this->count;
+        return count($this->elements);
+    }
+
+    /**
+     *  getTotalItems
+     *
+     *  @return integer
+     */
+    public function getTotalItems()
+    {
+        return $this->count();
     }
 
     /**
@@ -116,15 +120,5 @@ class HydraCollection implements \IteratorAggregate, \Serializable, \Countable, 
     public function getIterator()
     {
         return new ArrayIterator($this->elements);
-    }
-
-    /**
-     *  getTotalItems
-     *
-     *  @return integer
-     */
-    public function getTotalItems()
-    {
-        return $this->count();
     }
 }

--- a/src/Collection/HydraCollection.php
+++ b/src/Collection/HydraCollection.php
@@ -11,43 +11,66 @@ use \ArrayIterator;
  */
 class HydraCollection implements \IteratorAggregate, \Serializable, \Countable, \ArrayAccess
 {
+    /**
+     * @var array the elements of the collection
+     */
     private $elements;
-    private $count = 0;
-    private $totalItems = 0;
 
+    /**
+     * @var integer the number of elements
+     */
+    private $count = 0;
+
+    /**
+     * @param array response - The Hydra data as an array
+     */
     public function __construct($response)
     {
         $this->elements = $response['hydra:member'];
         $this->count = count($this->elements);
-
-        if (!empty($response['hydra:totalItems'])) {
-            $this->totalItems = $response['hydra:totalItems'];
-        }
     }
 
     /**
-     *  return array
+     *  toArray
+     *
+     *  @return array
      */
     public function toArray()
     {
         return $this->elements;
     }
 
+    /**
+     *  serialize
+     *
+     *  @return string
+     */
     public function serialize()
     {
         return serialize($this->elements);
     }
 
+    /**
+     *  unserialize
+     */
     public function unserialize($values)
     {
         $this->elements = unserialize($values);
     }
 
+    /**
+     *  count
+     *
+     *  @return int
+     */
     public function count()
     {
         return $this->count;
     }
 
+    /**
+     *  ArrayAccess implementation of offsetSet()
+     */
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -57,31 +80,51 @@ class HydraCollection implements \IteratorAggregate, \Serializable, \Countable, 
         }
     }
 
+    /**
+     *  ArrayAccess implementation of offsetExists()
+     *
+     *  @return bool
+     */
     public function offsetExists($offset)
     {
         return isset($this->elements[$offset]);
     }
 
+    /**
+     *  ArrayAccess implementation of offsetUnset()
+     */
     public function offsetUnset($offset)
     {
         unset($this->elements[$offset]);
     }
 
+    /**
+     *  ArrayAccess implementation of offsetGet()
+     *
+     *  @return mixed
+     */
     public function offsetGet($offset)
     {
         return isset($this->elements[$offset]) ? $this->elements[$offset] : null;
     }
 
+    /**
+     * getIterator
+     *
+     * @return \ArrayIterator
+     */
     public function getIterator()
     {
         return new ArrayIterator($this->elements);
     }
 
     /**
-     *  return int
+     *  getTotalItems
+     *
+     *  @return integer
      */
     public function getTotalItems()
     {
-        return $this->totalItems;
+        return $this->count();
     }
 }

--- a/src/Collection/HydraCollection.php
+++ b/src/Collection/HydraCollection.php
@@ -19,9 +19,13 @@ class HydraCollection implements \IteratorAggregate, \Serializable, \Countable, 
     /**
      * @param array response - The Hydra data as an array
      */
-    public function __construct($response)
+    public function __construct($response = [])
     {
-        $this->elements = $response['hydra:member'];
+        if (!empty($response['hydra:member'])) {
+            $this->elements = $response['hydra:member'];
+        } else {
+            $this->elements = [];
+        }
     }
 
     /**

--- a/src/Collection/HydraPaginatedCollection.php
+++ b/src/Collection/HydraPaginatedCollection.php
@@ -9,10 +9,29 @@ namespace Mapado\RestClientSdk\Collection;
  */
 class HydraPaginatedCollection extends HydraCollection
 {
+    /**
+     * @var string URI of the first page
+     */
     private $firstPage = null;
+
+    /**
+    * @var string URI of the last page
+     */
     private $lastPage = null;
+
+    /**
+    * @var string URI of the next page
+     */
     private $nextPage = null;
 
+    /**
+     * @var integer the total number of elements regardless of the pagination
+     */
+    private $totalItems = 0;
+
+    /**
+     * @param array response - The Hydra data as an array
+     */
     public function __construct($response)
     {
         parent::__construct($response);
@@ -28,10 +47,16 @@ class HydraPaginatedCollection extends HydraCollection
         if (!empty($response['hydra:nextPage'])) {
             $this->nextPage = $response['hydra:nextPage'];
         }
+
+        if (!empty($response['hydra:totalItems'])) {
+            $this->totalItems = $response['hydra:totalItems'];
+        }
     }
 
     /**
-     *  return mixed
+     *  getFirstPage
+     *
+     *  @return mixed
      */
     public function getFirstPage()
     {
@@ -39,7 +64,9 @@ class HydraPaginatedCollection extends HydraCollection
     }
 
     /**
-     *  return mixed
+     *  getLastPage
+     *
+     *  @return mixed
      */
     public function getLastPage()
     {
@@ -49,10 +76,20 @@ class HydraPaginatedCollection extends HydraCollection
     /**
      *  getNextPage
      *
-     *  return mixed
+     *  @return mixed
      */
     public function getNextPage()
     {
         return $this->nextPage;
+    }
+
+    /**
+     *  getTotalItems
+     *
+     *  @return integer
+     */
+    public function getTotalItems()
+    {
+        return $this->totalItems;
     }
 }

--- a/src/Collection/HydraPaginatedCollection.php
+++ b/src/Collection/HydraPaginatedCollection.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Mapado\RestClientSdk\Collection;
+
+/**
+ * Class HydraPaginatedCollection
+ *
+ * @author Florent Clerc <florent.clerc@mapado.com>
+ */
+class HydraPaginatedCollection extends HydraCollection
+{
+    private $firstPage = null;
+    private $lastPage = null;
+    private $nextPage = null;
+
+    public function __construct($response)
+    {
+        parent::__construct($response);
+
+        if (!empty($response['hydra:firstPage'])) {
+            $this->firstPage = $response['hydra:firstPage'];
+        }
+
+        if (!empty($response['hydra:lastPage'])) {
+            $this->lastPage = $response['hydra:lastPage'];
+        }
+
+        if (!empty($response['hydra:nextPage'])) {
+            $this->nextPage = $response['hydra:nextPage'];
+        }
+    }
+
+    /**
+     *  return mixed
+     */
+    public function getFirstPage()
+    {
+        return $this->firstPage;
+    }
+
+    /**
+     *  return mixed
+     */
+    public function getLastPage()
+    {
+        return $this->lastPage;
+    }
+
+    /**
+     *  getNextPage
+     *
+     *  return mixed
+     */
+    public function getNextPage()
+    {
+        return $this->nextPage;
+    }
+}

--- a/src/Model/ModelHydrator.php
+++ b/src/Model/ModelHydrator.php
@@ -2,6 +2,8 @@
 
 namespace Mapado\RestClientSdk\Model;
 
+use Mapado\RestClientSdk\Collection\HydraCollection;
+use Mapado\RestClientSdk\Collection\HydraPaginatedCollection;
 use Mapado\RestClientSdk\SdkClient;
 
 /**

--- a/src/Model/ModelHydrator.php
+++ b/src/Model/ModelHydrator.php
@@ -84,20 +84,16 @@ class ModelHydrator
     public function hydrateList($data, $modelName)
     {
         if ($data && is_array($data) && !empty($data['hydra:member'])) {
-            $hydratedList = [];
             if (!empty($data) && !empty($data['hydra:member'])) {
-                $hydratedList = $this->deserializeAll($data, $modelName);
+                return $this->deserializeAll($data, $modelName);
             }
-
-            return $hydratedList;
         }
 
-        return [];
+        return new HydraCollection();
     }
 
     public function deserializeAll($data, $modelName)
     {
-        $hydratedList = [];
 
         $data['hydra:member'] = array_map(
             function ($member) use ($modelName) {
@@ -106,10 +102,10 @@ class ModelHydrator
             $data['hydra:member']
         );
 
+        $hydratedList = new HydraCollection($data);
+
         if (!empty($data['@type'])) {
-            if ($data['@type'] === 'hydra:Collection') {
-                $hydratedList = new HydraCollection($data);
-            } elseif ($data['@type'] === 'hydra:PagedCollection') {
+            if ($data['@type'] === 'hydra:PagedCollection') {
                 $hydratedList = new HydraPaginatedCollection($data);
             }
         }

--- a/src/Model/ModelHydrator.php
+++ b/src/Model/ModelHydrator.php
@@ -13,33 +13,33 @@ use Mapado\RestClientSdk\SdkClient;
 */
 class ModelHydrator
 {
-   /**
-   * sdk
-   *
-   * @var    SdkClient
-   * @access private
-   */
+    /**
+     * sdk
+     *
+     * @var SdkClient
+     * @access private
+     */
     protected $sdk;
 
     /**
-    * __construct
-    *
-    * @param  RestClient
-    * @access public
-    */
+     * __construct
+     *
+     * @param RestClient
+     * @access public
+     */
     public function __construct(SdkClient $sdk)
     {
         $this->sdk = $sdk;
     }
 
     /**
-    * convertId
-    *
-    * @param  string $id
-    * @param  string $modelName
-    * @access public
-    * @return string
-    */
+      * convertId
+      *
+      * @param string $id
+      * @param string $modelName
+      * @access public
+      * @return string
+      */
     public function convertId($id, $modelName)
     {
         // add slash if needed to have a valid hydra id
@@ -57,13 +57,13 @@ class ModelHydrator
     }
 
     /**
-    * hydrate
-    *
-    * @param  array  $data
-    * @param  string $modelName
-    * @access public
-    * @return object
-    */
+     * hydrate
+     *
+     * @param array $data
+     * @param string $modelName
+     * @access public
+     * @return object
+     */
     public function hydrate($data, $modelName)
     {
         $mapping = $this->sdk->getMapping();
@@ -74,13 +74,13 @@ class ModelHydrator
     }
 
     /**
-    * hydrateList
-    *
-    * @param  array  $data
-    * @param  string $modelName
-    * @access public
-    * @return array
-    */
+     * hydrateList
+     *
+     * @param array $data
+     * @param string $modelName
+     * @access public
+     * @return array
+     */
     public function hydrateList($data, $modelName)
     {
         if ($data && is_array($data) && !empty($data['hydra:member'])) {
@@ -114,13 +114,13 @@ class ModelHydrator
     }
 
     /**
-    * deserialize
-    *
-    * @param  array  $data
-    * @param  string $modelName
-    * @access private
-    * @return object
-    */
+     * deserialize
+     *
+     * @param array $data
+     * @param string $modelName
+     * @access private
+     * @return object
+     */
     private function deserialize($data, $modelName)
     {
         if (!$data) {

--- a/src/Model/ModelHydrator.php
+++ b/src/Model/ModelHydrator.php
@@ -8,12 +8,12 @@ use Mapado\RestClientSdk\SdkClient;
 
 /**
 * Class ModelHydrator
- *
+*
 * @author Julien Deniau <julien.deniau@mapado.com>
 */
 class ModelHydrator
 {
-    /**
+   /**
    * sdk
    *
    * @var    SdkClient
@@ -22,24 +22,24 @@ class ModelHydrator
     protected $sdk;
 
     /**
-   * __construct
-   *
-   * @param  RestClient
-   * @access public
-   */
+    * __construct
+    *
+    * @param  RestClient
+    * @access public
+    */
     public function __construct(SdkClient $sdk)
     {
         $this->sdk = $sdk;
     }
 
     /**
-   * convertId
-   *
-   * @param  string $id
-   * @param  string $modelName
-   * @access public
-   * @return string
-   */
+    * convertId
+    *
+    * @param  string $id
+    * @param  string $modelName
+    * @access public
+    * @return string
+    */
     public function convertId($id, $modelName)
     {
         // add slash if needed to have a valid hydra id
@@ -57,13 +57,13 @@ class ModelHydrator
     }
 
     /**
-   * hydrate
-   *
-   * @param  array  $data
-   * @param  string $modelName
-   * @access public
-   * @return object
-   */
+    * hydrate
+    *
+    * @param  array  $data
+    * @param  string $modelName
+    * @access public
+    * @return object
+    */
     public function hydrate($data, $modelName)
     {
         $mapping = $this->sdk->getMapping();
@@ -74,13 +74,13 @@ class ModelHydrator
     }
 
     /**
-   * hydrateList
-   *
-   * @param  array  $data
-   * @param  string $modelName
-   * @access public
-   * @return array
-   */
+    * hydrateList
+    *
+    * @param  array  $data
+    * @param  string $modelName
+    * @access public
+    * @return array
+    */
     public function hydrateList($data, $modelName)
     {
         if ($data && is_array($data) && !empty($data['hydra:member'])) {
@@ -118,13 +118,13 @@ class ModelHydrator
     }
 
     /**
-   * deserialize
-   *
-   * @param  array  $data
-   * @param  string $modelName
-   * @access private
-   * @return object
-   */
+    * deserialize
+    *
+    * @param  array  $data
+    * @param  string $modelName
+    * @access private
+    * @return object
+    */
     private function deserialize($data, $modelName)
     {
         if (!$data) {


### PR DESCRIPTION
This is a proposal to allow the client to get the pagination information when we have a hydra:PaginatedCollection

Basically, when hydrating a list, instead of returning an array, we wrap it on a custom collection Object (very similar to [Doctrine's ArrayCollection](http://www.doctrine-project.org/api/common/2.1/class-Doctrine.Common.Collections.ArrayCollection.html)

Please note there is a BC change:
Even though the HydraCollection object acts as an array (implementing ArrayAccess, IteratorAggregate, and Countable), it is not possible anymore to use array functions on the results (such as array_map, array_filter, ...)

I'll ping @Steit in case there is any problem with this change

