### PR TITLE
update Mapping.getKeyFromId for more complicated id URI

### DIFF
--- a/Tests/Units/Mapping.php
+++ b/Tests/Units/Mapping.php
@@ -104,6 +104,13 @@ class Mapping extends atoum
             ->then
                 ->string($this->testedInstance->getKeyFromId('/orders/8'))
                     ->isEqualTo('orders')
+
+            // a really complicated id
+            ->given($this->newTestedInstance)
+                ->and($this->testedInstance->setMapping($this->getMappingArray()))
+            ->then
+                ->string($this->testedInstance->getKeyFromId('/sales/customers/3/orders/8'))
+                    ->isEqualTo('orders')
         ;
     }
 

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -93,7 +93,12 @@ class Mapping
     public function getKeyFromId($id)
     {
         $id = $this->removePrefix($id);
-        $key = substr($id, 1, strrpos($id, '/') - 1);
+
+        $lastSeparator = strrpos($id, '/');
+        $secondLast = strrpos($id, '/', $lastSeparator - strlen($id) - 1) + 1;
+
+        $keyLength = abs($secondLast - $lastSeparator);
+        $key = substr($id, $secondLast, $keyLength);
         $this->checkMappingExistence($key);
 
         return $key;


### PR DESCRIPTION
In the current version, if we have an id with a complicated URI (ie. `/sales/customers/3/orders/8`), the compputed mapping would be `sales/customers/3/orders`, which would be complicated to map with the annotation `Rest\Entity.`

This PR changes how it works, the model key will be what's between the last and the second-last `/`