### PR TITLE
serialize one more level so we can send relations in one query

### DIFF
--- a/Tests/Units/Model/Serializer.php
+++ b/Tests/Units/Model/Serializer.php
@@ -77,7 +77,18 @@ class Serializer extends atoum
                         'clientPhoneNumber' => '+33 1 23 45 67 89',
                         'createdAt' => (new \DateTime('2015-09-20T12:08:00'))->format(DateTime::RFC3339),
                         'cartItemList' => [
-                            '/v1/cart_items/16',
+                            [
+                                '@id' => '/v1/cart_items/16',
+                                'amount' => 1,
+                                'createdAt' => (new \DateTime('2015-11-04 15:13:00'))->format(DateTime::RFC3339),
+                                'data' => [
+                                    'when' => (new \DateTime('2015-11-04 15:00:00'))->format(DateTime::RFC3339),
+                                    'who' => 'Jane',
+                                ],
+                                'cart' => '/v1/carts/8',
+                                'product' => '/v1/products/10',
+                                'cartItemDetailList' => [],
+                            ],
                         ],
                     ])
 
@@ -230,7 +241,18 @@ class Serializer extends atoum
                         'clientPhoneNumber' => '+33 1 23 45 67 89',
                         'createdAt' => (new \DateTime('2015-09-20T12:08:00'))->format(DateTime::RFC3339),
                         'cartItemList' => [
-                            '/v1/cart_items/16',
+                            [
+                                '@id' => '/v1/cart_items/16',
+                                'amount' => 1,
+                                'createdAt' => (new \DateTime('2015-11-04 15:13:00'))->format(DateTime::RFC3339),
+                                'data' => [
+                                    'when' => (new \DateTime('2015-11-04 15:00:00'))->format(DateTime::RFC3339),
+                                    'who' => 'Jane',
+                                ],
+                                'cart' => '/v1/carts/8',
+                                'product' => '/v1/products/10',
+                                'cartItemDetailList' => [],
+                            ],
                             [
                                 'amount' => 2,
                                 'createdAt' => (new \DateTime('2015-09-20T12:11:00'))->format(DateTime::RFC3339),
@@ -530,6 +552,13 @@ class Serializer extends atoum
     {
         $cartItem = $this->createNewCartItem();
         $cartItem->setId('/v1/cart_items/16');
+        $cartItem->setAmount(1);
+        $cartItem->setCreatedAt(new DateTime('2015-11-04 15:13:00'));
+        $cartItem->setData([
+            'when' => new DateTime('2015-11-04 15:00:00'),
+            'who' => 'Jane',
+        ]);
+        $cartItem->setCart($this->createCart());
 
         return $cartItem;
     }
@@ -613,6 +642,34 @@ class Serializer extends atoum
         $this->mockGenerator->unshuntParentClassCalls();
         $sdk = new \mock\Mapado\RestClientSdk\SdkClient($restClient, $this->getMapping(), $this->testedInstance);
 
+        $cartRepositoryMock = $this->getCartRepositoryMock($sdk, $restClient, 'Mapado\RestClientSdk\Tests\Model\Cart');
+
+        $this->calling($sdk)->getRepository = function($modelName) use($cartRepositoryMock) {
+            switch($modelName) {
+                case 'Mapado\RestClientSdk\Tests\Model\Cart':
+                    return $cartRepositoryMock;
+                default:
+                    return null;
+            }
+        };
+
         $this->testedInstance->setSdk($sdk);
+    }
+
+    private function getCartRepositoryMock($sdk, $restClient, $modelName)
+    {
+        $repository = new \mock\Mapado\RestClientSdk\EntityRepository(
+            $sdk,
+            $restClient,
+            $modelName
+        );
+
+        $_this = $this;
+
+        $this->calling($repository)->find = function($id) use ($_this) {
+            return $_this->createCart();
+        };
+
+        return $repository;
     }
 }

--- a/src/Model/Serializer.php
+++ b/src/Model/Serializer.php
@@ -132,7 +132,7 @@ class Serializer
      */
     private function recursiveSerialize($entity, $modelName, $level = 0)
     {
-        if ($level > 0 && $entity->getId()) {
+        if ($level > 1 && $entity->getId()) {
             return $entity->getId();
         }
 

--- a/src/SdkClient.php
+++ b/src/SdkClient.php
@@ -205,7 +205,6 @@ class SdkClient
         ) {
             if ($method !== 'getId' && $method !== 'setId' && $method !== 'jsonSerialize') {
                 $initializer   = null; // disable initialization
-
                 // load data and modify the object here
                 if ($id) {
                     $repository = $sdk->getRepository($classMetadata->getModelName());


### PR DESCRIPTION
This pull request allows one more level in the serialization, so if we want to send relation data (eg OneToMany) in a POST or a PUT we can do it in one query instead of multiple.

The repository mock in the test files are only there to make sure the cart is properly serialized (ie only its id) from the cartItem, maybe it's not that useful to test