### PR TITLE
Remove useless repository reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,13 +86,6 @@
       ]
     }
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/jdeniau/config-extension",
-      "no-api": true
-    }
-  ],
   "config": {
     "allow-plugins": {
       "g1a/composer-test-scenarios": true


### PR DESCRIPTION
Remove the useless vcs repository reference, was used for the atoum configuration before but now PHPUnit is used ;)
