### PR TITLE
Expose type alias

### DIFF
--- a/aliases.neon
+++ b/aliases.neon
@@ -1,0 +1,3 @@
+parameters:
+    typeAliases:
+      SerializerContext: 'array{serializeRelations?: array<string>}'

--- a/package.json
+++ b/package.json
@@ -13,6 +13,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/phpstan-extension/extension.neon
+++ b/phpstan-extension/extension.neon
@@ -1,3 +1,6 @@
+includes:
+  - 'aliases.neon'
+
 parameters:
     rest_client_sdk:
       registryFile: null

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,10 @@
 includes:
   - 'phpstan-baseline.neon'
+  - 'aliases.neon'
 
 parameters:
     level: max
     ignoreErrors: []
-
-    typeAliases:
-      SerializerContext: 'array{serializeRelations?: array<string>}'
 
     paths:
         - src


### PR DESCRIPTION
We expose `SerializerContext` type alias in extension

Required for other projects who use rest-client-sdk 