### PR TITLE
Types class constant

### DIFF
--- a/src/Mapping/Attribute.php
+++ b/src/Mapping/Attribute.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Mapado\RestClientSdk\Mapping;
 
+use Mapado\RestClientSdk\Types;
+
 /**
  * Class Attribute
  *
@@ -46,7 +48,7 @@ class Attribute
 
         $this->serializedKey = $serializedKey;
         $this->attributeName = $attributeName ?? $this->serializedKey;
-        $this->type = $type ?? 'string';
+        $this->type = $type ?? Types::STRING;
         $this->isIdentifier = $isIdentifier;
     }
 

--- a/src/Model/Serializer.php
+++ b/src/Model/Serializer.php
@@ -14,6 +14,7 @@ use Mapado\RestClientSdk\Helper\ArrayHelper;
 use Mapado\RestClientSdk\Mapping;
 use Mapado\RestClientSdk\Mapping\ClassMetadata;
 use Mapado\RestClientSdk\SdkClient;
+use Mapado\RestClientSdk\Types;
 use Mapado\RestClientSdk\UnitOfWork;
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -154,7 +155,7 @@ class Serializer
                 }
 
                 if (isset($value)) {
-                    if ('datetime' === $attribute->getType()) {
+                    if (Types::DATETIME === $attribute->getType()) {
                         if (!is_string($value)) {
                             throw new \RuntimeException(
                                 "The value for $attributeName to cast to datetime value should be a string",

--- a/src/Types.php
+++ b/src/Types.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mapado\RestClientSdk;
+
+class Types
+{
+    public const STRING = 'string';
+    public const INTEGER = 'integer';
+    public const FLOAT = 'float';
+    public const BOOLEAN = 'boolean';
+    public const DATETIME = 'datetime';
+    public const JSON_ARRAY = 'json_array';
+    public const ARRAY = 'array';
+}


### PR DESCRIPTION
### Nouveau comportement

Pour avoir une classe avec les types "supportés" par le serializer, et éviter les typos.

Ainsi on aurait un truc comme ceci : 
```php
#[Rest\Attribute(name: '@id', type: Types::STRING)]
private $id;
```
Même si on dirait que c'est assez freestyle les types, et qu'on fait rien de particulier avec sauf avec les `datetime`. (je sais pas)