### PR TITLE
Accept class-string for targetEntity in Relation attribute

### DIFF
--- a/Tests/Model/Issue46/Article.php
+++ b/Tests/Model/Issue46/Article.php
@@ -15,16 +15,10 @@ class Article
     ]
     private $iri;
 
-    /**
-     * @Rest\Attribute(name="id", type="string")
-     */
     #[Rest\Attribute(name: 'id', type: 'string')]
     private $id;
 
-    /**
-     * @Rest\ManyToOne(name="section", targetEntity="Section")
-     */
-    #[Rest\ManyToOne(name: 'section', targetEntity: 'Section')]
+    #[Rest\ManyToOne(name: 'section', targetEntity: Section::class)]
     private $section;
 
     public function setId($id): void

--- a/Tests/Model/Issue46/Section.php
+++ b/Tests/Model/Issue46/Section.php
@@ -21,7 +21,7 @@ class Section
     #[Rest\Attribute(name: 'title', type: 'string')]
     private $title;
 
-    #[Rest\OneToMany(name: 'articleList', targetEntity: 'Article')]
+    #[Rest\OneToMany(name: 'articleList', targetEntity: Article::class)]
     private $articleList = [];
 
     public function setId($id): void

--- a/Tests/Model/Issue75/Article.php
+++ b/Tests/Model/Issue75/Article.php
@@ -9,11 +9,6 @@ use Mapado\RestClientSdk\Mapping\Attributes as Rest;
 #[Rest\Entity(key: 'articles')]
 class Article
 {
-    /**
-     * @Rest\Id
-     *
-     * @Rest\Attribute(name="@id", type="string")
-     */
     #[
         Rest\Id,
         Rest\Attribute(name: '@id', type: 'string')
@@ -23,10 +18,10 @@ class Article
     #[Rest\Attribute(name: 'title', type: 'string')]
     private $title;
 
-    #[Rest\ManyToOne(name: 'tag', targetEntity: 'Tag')]
+    #[Rest\ManyToOne(name: 'tag', targetEntity: Tag::class)]
     private $tag;
 
-    #[Rest\OneToMany(name: 'tagList', targetEntity: 'Tag')]
+    #[Rest\OneToMany(name: 'tagList', targetEntity: Tag::class)]
     private $tagList;
 
     public function setTitle($title): void

--- a/Tests/Model/Issue80/Article.php
+++ b/Tests/Model/Issue80/Article.php
@@ -11,16 +11,11 @@ class Article
 {
     /**
      * @var int
-     *
-     * @Rest\Id
-     *
-     * @Rest\Attribute(name="id", type="int")
      */
+    #[Rest\Id]
+    #[Rest\Attribute(name: 'id', type: 'string')]
     private $id;
 
-    /**
-     * @Rest\Attribute(name="title", type="string")
-     */
     #[Rest\Attribute(name: 'title', type: 'string')]
     private $title;
 

--- a/Tests/Model/JsonLd/Cart.php
+++ b/Tests/Model/JsonLd/Cart.php
@@ -27,7 +27,7 @@ class Cart
     #[Rest\Attribute(name: 'created_at', type: 'datetime')]
     private $createdAt;
 
-    #[Rest\OneToMany(name: 'cart_items', targetEntity: 'CartItem')]
+    #[Rest\OneToMany(name: 'cart_items', targetEntity: CartItem::class)]
     private $cartItemList = [];
 
     /**
@@ -38,7 +38,7 @@ class Cart
     #[Rest\Attribute(name: 'clientPhoneNumber', type: 'phone_number')]
     private $clientPhoneNumber;
 
-    #[Rest\ManyToOne(name: 'order', targetEntity: 'Order')]
+    #[Rest\ManyToOne(name: 'order', targetEntity: Order::class)]
     private $order;
 
     /**

--- a/Tests/Model/JsonLd/CartItem.php
+++ b/Tests/Model/JsonLd/CartItem.php
@@ -43,7 +43,7 @@ class CartItem
     /**
      * cart
      */
-    #[Rest\ManyToOne(name: 'cart', targetEntity: 'Cart')]
+    #[Rest\ManyToOne(name: 'cart', targetEntity: Cart::class)]
     private $cart;
 
     /**

--- a/Tests/Model/JsonLd/Invalid.php
+++ b/Tests/Model/JsonLd/Invalid.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mapado\RestClientSdk\Tests\Model\JsonLd;
+
+use Mapado\RestClientSdk\Mapping\Attributes\Entity;
+use Mapado\RestClientSdk\Mapping\Attributes\ManyToOne;
+
+#[Entity('invalid')]
+class Invalid
+{
+    #[ManyToOne('client', Client::class)]
+    private $client;
+
+    public function getClient(): Client
+    {
+        return $this->client;
+    }
+}

--- a/Tests/Model/JsonLd/Model.php
+++ b/Tests/Model/JsonLd/Model.php
@@ -13,11 +13,6 @@ use Mapado\RestClientSdk\Mapping\Attributes as Rest;
  */
 class Model
 {
-    /**
-     * @Rest\Id
-     *
-     * @Rest\Attribute(name="id", type="string")
-     */
     #[Rest\Id]
     #[Rest\Attribute(name: 'id', type: 'string')]
     private $id;

--- a/Tests/Units/Mapping/Driver/AttributeDriverTest.php
+++ b/Tests/Units/Mapping/Driver/AttributeDriverTest.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Mapado\RestClientSdk\Tests\Units\Mapping\Driver;
 
+use Mapado\RestClientSdk\Exception\MappingException;
+use Mapado\RestClientSdk\Mapping\Attribute;
+use Mapado\RestClientSdk\Mapping\ClassMetadata;
 use Mapado\RestClientSdk\Mapping\Driver\AttributeDriver;
 use Mapado\RestClientSdk\Mapping\Relation;
 use Mapado\RestClientSdk\Tests\Model\JsonLd\Cart;
 use Mapado\RestClientSdk\Tests\Model\JsonLd\CartItem;
+use Mapado\RestClientSdk\Tests\Model\JsonLd\Client;
+use Mapado\RestClientSdk\Tests\Model\JsonLd\Invalid;
+use Mapado\RestClientSdk\Tests\Model\JsonLd\ModelRepository;
+use Mapado\RestClientSdk\Tests\Model\JsonLd\Product;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,8 +29,20 @@ class AttributeDriverTest extends TestCase
     {
         $testedInstance = new AttributeDriver($this->getCacheDir(), true);
 
-        $mapping = $testedInstance->loadClassname('Mapado\RestClientSdk\Tests\Model\JsonLd\Client');
+        $mapping = $testedInstance->loadClassname(Client::class);
         $this->assertEmpty($mapping);
+    }
+
+    /**
+     * testClassWithoutEntityAnnotation
+     */
+    public function testClassWithInvalidProperty(): void
+    {
+        $testedInstance = new AttributeDriver($this->getCacheDir(), true);
+
+        $this->expectException(MappingException::class);
+
+        $mapping = $testedInstance->loadClassname(Invalid::class);
     }
 
     /**
@@ -33,20 +52,20 @@ class AttributeDriverTest extends TestCase
     {
         $testedInstance = new AttributeDriver($this->getCacheDir(), true);
 
-        $mapping = $testedInstance->loadClassname('Mapado\RestClientSdk\Tests\Model\JsonLd\Product');
+        $mapping = $testedInstance->loadClassname(Product::class);
         $this->assertCount(1, $mapping);
 
         $classMetadata = current($mapping);
-        $this->assertInstanceOf('Mapado\RestClientSdk\Mapping\ClassMetadata', $classMetadata);
+        $this->assertInstanceOf(ClassMetadata::class, $classMetadata);
         $this->assertEquals('product', $classMetadata->getKey());
-        $this->assertEquals('Mapado\RestClientSdk\Tests\Model\JsonLd\Product', $classMetadata->getModelName());
-        $this->assertEquals('Mapado\RestClientSdk\Tests\Model\JsonLd\ModelRepository', $classMetadata->getRepositoryName());
+        $this->assertEquals(Product::class, $classMetadata->getModelName());
+        $this->assertEquals(ModelRepository::class, $classMetadata->getRepositoryName());
 
         $attributeList = $classMetadata->getAttributeList();
         $this->assertCount(3, $attributeList);
 
         $attribute = current($attributeList);
-        $this->assertInstanceOf('Mapado\RestClientSdk\Mapping\Attribute', $attribute);
+        $this->assertInstanceOf(Attribute::class, $attribute);
         $this->assertEquals('id', $attribute->getSerializedKey());
 
         $attribute = next($attributeList);
@@ -62,7 +81,7 @@ class AttributeDriverTest extends TestCase
         $this->assertCount(1, $mapping);
 
         $classMetadata = current($mapping);
-        $this->assertInstanceOf('Mapado\RestClientSdk\Mapping\ClassMetadata', $classMetadata);
+        $this->assertInstanceOf(ClassMetadata::class, $classMetadata);
         $this->assertEquals('cart', $classMetadata->getKey());
 
         $attributeList = $classMetadata->getAttributeList();
@@ -76,7 +95,7 @@ class AttributeDriverTest extends TestCase
         $this->assertCount(1, $mapping);
 
         $classMetadata = current($mapping);
-        $this->assertInstanceOf('Mapado\RestClientSdk\Mapping\ClassMetadata', $classMetadata);
+        $this->assertInstanceOf(ClassMetadata::class, $classMetadata);
         $this->assertEquals('cart_item', $classMetadata->getKey());
 
         $attributeList = $classMetadata->getAttributeList();

--- a/Tests/Units/Mapping/Driver/AttributeDriverTest.php
+++ b/Tests/Units/Mapping/Driver/AttributeDriverTest.php
@@ -6,6 +6,8 @@ namespace Mapado\RestClientSdk\Tests\Units\Mapping\Driver;
 
 use Mapado\RestClientSdk\Mapping\Driver\AttributeDriver;
 use Mapado\RestClientSdk\Mapping\Relation;
+use Mapado\RestClientSdk\Tests\Model\JsonLd\Cart;
+use Mapado\RestClientSdk\Tests\Model\JsonLd\CartItem;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -56,7 +58,7 @@ class AttributeDriverTest extends TestCase
     {
         $testedInstance = new AttributeDriver($this->getCacheDir(), true);
 
-        $mapping = $testedInstance->loadClassname('Mapado\RestClientSdk\Tests\Model\JsonLd\Cart');
+        $mapping = $testedInstance->loadClassname(Cart::class);
         $this->assertCount(1, $mapping);
 
         $classMetadata = current($mapping);
@@ -70,7 +72,7 @@ class AttributeDriverTest extends TestCase
         $this->assertCount(2, $relationList);
         $this->assertEquals(Relation::ONE_TO_MANY, current($relationList)->getType());
 
-        $mapping = $testedInstance->loadClassname('Mapado\RestClientSdk\Tests\Model\JsonLd\CartItem');
+        $mapping = $testedInstance->loadClassname(CartItem::class);
         $this->assertCount(1, $mapping);
 
         $classMetadata = current($mapping);
@@ -84,7 +86,7 @@ class AttributeDriverTest extends TestCase
         $this->assertCount(1, $relationList);
         $relation = current($relationList);
         $this->assertEquals(Relation::MANY_TO_ONE, $relation->getType());
-        $this->assertEquals('Mapado\RestClientSdk\Tests\Model\JsonLd\Cart', $relation->getTargetEntity());
+        $this->assertEquals(Cart::class, $relation->getTargetEntity());
     }
 
     public function testLoadDirectory(): void

--- a/Tests/Units/Model/SerializerTest.php
+++ b/Tests/Units/Model/SerializerTest.php
@@ -732,7 +732,7 @@ class SerializerTest extends TestCase
             ],
             $this->testedInstance->serialize(
                 $article,
-                'Mapado\RestClientSdk\Tests\Model\Issue46\Article'
+                Issue46\Article::class
             )
         );
 
@@ -747,7 +747,7 @@ class SerializerTest extends TestCase
             ],
             $this->testedInstance->serialize(
                 $section,
-                'Mapado\RestClientSdk\Tests\Model\Issue46\Section'
+                Issue46\Section::class
             )
         );
 
@@ -766,7 +766,7 @@ class SerializerTest extends TestCase
             ],
             $this->testedInstance->serialize(
                 $section,
-                'Mapado\RestClientSdk\Tests\Model\Issue46\Section',
+                Issue46\Section::class,
                 ['serializeRelations' => ['articleList']]
             )
         );

--- a/package.json
+++ b/package.json
@@ -13,6 +13,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/Mapping/Attributes/Relation.php
+++ b/src/Mapping/Attributes/Relation.php
@@ -6,6 +6,9 @@ namespace Mapado\RestClientSdk\Mapping\Attributes;
 
 abstract class Relation
 {
+    /**
+     * @param class-string $targetEntity
+     */
     public function __construct(
         public readonly string $name,
         public readonly string $targetEntity,

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -137,7 +137,7 @@ class AttributeDriver
                     );
                 }
 
-                if ($relation) {
+                if ($relation instanceof Attributes\Relation) {
                     $attributeList[] = new Attribute(
                         $relation->name,
                         $property->getName(),
@@ -145,6 +145,7 @@ class AttributeDriver
 
                     $targetEntity = $relation->targetEntity;
                     if (false === mb_strpos($targetEntity, '/')) {
+                        /** @var class-string $targetEntity */
                         $targetEntity =
                             mb_substr(
                                 $classname,

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -145,6 +145,9 @@ class AttributeDriver
                     );
 
                     $targetEntity = $relation->targetEntity;
+                    if (null === $this->getClassMetadataForClassname($targetEntity)) {
+                        throw new MappingException("Invalid targetEntity");
+                    }
 
                     $relationList[] = new Relation(
                         $relation->name,

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -9,6 +9,7 @@ use Mapado\RestClientSdk\Mapping\Attribute;
 use Mapado\RestClientSdk\Mapping\Attributes;
 use Mapado\RestClientSdk\Mapping\ClassMetadata;
 use Mapado\RestClientSdk\Mapping\Relation;
+use function PHPStan\dumpType;
 
 /**
  * Class AttributeDriver
@@ -144,15 +145,6 @@ class AttributeDriver
                     );
 
                     $targetEntity = $relation->targetEntity;
-                    if (false === mb_strpos($targetEntity, '/')) {
-                        /** @var class-string $targetEntity */
-                        $targetEntity =
-                            mb_substr(
-                                $classname,
-                                0,
-                                mb_strrpos($classname, '\\') + 1,
-                            ) . $targetEntity;
-                    }
 
                     $relationList[] = new Relation(
                         $relation->name,

--- a/src/Mapping/Relation.php
+++ b/src/Mapping/Relation.php
@@ -15,31 +15,13 @@ class Relation
     public const ONE_TO_MANY = 'OneToMany';
 
     /**
-     * @var string
-     */
-    private $serializedKey;
-
-    /**
-     * @var string
-     */
-    private $type;
-
-    /**
-     * @var class-string
-     */
-    private $targetEntity;
-
-    /**
      * @param class-string $targetEntity
      */
     public function __construct(
-        string $serializedKey,
-        string $type,
-        string $targetEntity,
+        private string $serializedKey,
+        private string $type,
+        private string $targetEntity,
     ) {
-        $this->serializedKey = $serializedKey;
-        $this->type = $type;
-        $this->targetEntity = $targetEntity;
     }
 
     public function getSerializedKey(): string

--- a/src/Mapping/Relation.php
+++ b/src/Mapping/Relation.php
@@ -84,6 +84,9 @@ class Relation
         return $this->targetEntity;
     }
 
+    /**
+     * @param class-string $targetEntity
+     */
     public function setTargetEntity(string $targetEntity): self
     {
         $this->targetEntity = $targetEntity;

--- a/src/Mapping/Relation.php
+++ b/src/Mapping/Relation.php
@@ -25,10 +25,13 @@ class Relation
     private $type;
 
     /**
-     * @var string
+     * @var class-string
      */
     private $targetEntity;
 
+    /**
+     * @param class-string $targetEntity
+     */
     public function __construct(
         string $serializedKey,
         string $type,
@@ -73,6 +76,9 @@ class Relation
         return self::MANY_TO_ONE === $this->getType();
     }
 
+    /**
+     * @return class-string
+     */
     public function getTargetEntity(): string
     {
         return $this->targetEntity;


### PR DESCRIPTION
This PR enables providing class-fqcn with `::class` instead of harcdoded string class
