### PR TITLE
[cache] allow null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- allow null values in cache
+
 ## 2.0.0
 
 ### Changed
@@ -15,7 +19,9 @@ Go see the [migration guide](MIGRATION-2.0.md) to see how to migrate from v0 to 
 (wrongly pushed version, removed from packagist)
 
 ## 0.36.1
+
 - Collection.php compatibility with PHP 8.1
+
 ### Changed
 
 - [Breaking] Added compatibility for PHP 8.1
@@ -24,7 +30,7 @@ Go see the [migration guide](MIGRATION-2.0.md) to see how to migrate from v0 to 
 
 ### Changed
 
-Replace abandonned misd/phone-number-bundle 
+Replace abandonned misd/phone-number-bundle
 
 ## 0.34.0
 

--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -372,7 +372,7 @@ class EntityRepository
         return $out;
     }
 
-    protected function fetchFromCache(string $key): object|false
+    protected function fetchFromCache(string $key): object|null|false
     {
         $key = $this->normalizeCacheKey($key);
         $cacheItemPool = $this->sdk->getCacheItemPool();
@@ -382,9 +382,9 @@ class EntityRepository
                 $cacheItem = $cacheItemPool->getItem($cacheKey);
                 $cacheData = $cacheItem->get();
 
-                if (!is_object($cacheData)) {
+                if (!is_object($cacheData) && null !== $cacheData) {
                     throw new \RuntimeException(
-                        'Cache data should be an object. This should not happen.',
+                        'Cache data should either be null or an object. This should not happen.',
                     );
                 }
 


### PR DESCRIPTION
### Actual behavior

When we call the `findOneBy` method: 
- if there is no result, we put in cache [a `null` value](https://github.com/mapado/rest-client-sdk/blob/797c2196190aa219186372057e7ec86d5d72c1c3/src/EntityRepository.php#L143)
- we allow a `null` value [in the `saveToCache` method](https://github.com/mapado/rest-client-sdk/blob/797c2196190aa219186372057e7ec86d5d72c1c3/src/EntityRepository.php#L398)
	- if the cache key exists, we throw a `RuntimeException` [if the value is `null`](https://github.com/mapado/rest-client-sdk/blob/797c2196190aa219186372057e7ec86d5d72c1c3/src/EntityRepository.php#L385) (in the `fetchFromCache` method)

### New behavior

Considering the fact that the cache key is specific enough (ex: `oauth_mapado_rest_client__v1_customer_statuses?label=Etudiant&contract=%2Fv1%2Fcontracts%2F237&fields=id%2Clabel`), I think we can allow `null` values in the cache.