### PR TITLE
[phpstan-extension] fix include of aliases.neon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.0.2
+## 2.1.1
+
+- fix an error with phpstan-extension where phpstan was looking for an `aliases.neon` file
+
+## 2.1.0
 
 - allow null values in cache
 

--- a/phpstan-extension/extension.neon
+++ b/phpstan-extension/extension.neon
@@ -1,5 +1,5 @@
 includes:
-  - 'aliases.neon'
+  - '../aliases.neon'
 
 parameters:
     rest_client_sdk:


### PR DESCRIPTION
### Comportement actuel

<img width="1079" height="90" alt="image" src="https://github.com/user-attachments/assets/fca14c40-42ce-4cbb-87fc-d56690e45974" />


### Nouveau comportement

Le chemin vers `aliases.neon` est corrigé