### PR TITLE
fix php 84 deprecations

### DIFF
--- a/Tests/Units/EntityRepositoryTest.php
+++ b/Tests/Units/EntityRepositoryTest.php
@@ -792,8 +792,8 @@ class EntityRepositoryTest extends TestCase
      * }
      */
     private function getRepository(
-        RestMapping $mapping = null,
-        string $modelName = null,
+        ?RestMapping $mapping = null,
+        ?string $modelName = null,
         bool $mockHydrator = false,
         bool $mockUnitOfWork = false
     ): array {

--- a/Tests/Units/Model/SerializerTest.php
+++ b/Tests/Units/Model/SerializerTest.php
@@ -1185,7 +1185,7 @@ class SerializerTest extends TestCase
         return $item;
     }
 
-    private function createNewInstance(Mapping $mapping = null): void
+    private function createNewInstance(?Mapping $mapping = null): void
     {
         $mapping = $mapping ?: $this->getMapping();
         $this->unitOfWork = new UnitOfWork($mapping);


### PR DESCRIPTION
<details>
<summary>Details</summary>

```
FILE: /home/jravia/code/crm/vendor/mapado/rest-client-sdk/Tests/Units/Model/SerializerTest.php
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
 1188 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be
      |         | explicitly nullable instead. Found implicitly nullable parameter: $mapping.
      |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
------------------------------------------------------------------------------------------------------------------------


FILE: /home/jravia/code/crm/vendor/mapado/rest-client-sdk/Tests/Units/EntityRepositoryTest.php
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
------------------------------------------------------------------------------------------------------------------------
 795 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be
     |         | explicitly nullable instead. Found implicitly nullable parameter: $mapping.
     |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
 796 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be
     |         | explicitly nullable instead. Found implicitly nullable parameter: $modelName.
     |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
------------------------------------------------------------------------------------------------------------------------
```

</details>